### PR TITLE
fix Iterable import for py310

### DIFF
--- a/ofblockmeshdicthelper/__init__.py
+++ b/ofblockmeshdicthelper/__init__.py
@@ -3,7 +3,10 @@ from __future__ import unicode_literals, print_function
 from six import string_types
 
 import io
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from string import Template
 from itertools import groupby
 


### PR DESCRIPTION
Python 3.10 introduces breaking changes in the collections library.  This patch fixes that import